### PR TITLE
fix a bug caused when children is undefined.

### DIFF
--- a/appserver/static/visualizations/sunburst_viz/visualization.js
+++ b/appserver/static/visualizations/sunburst_viz/visualization.js
@@ -174,7 +174,7 @@ define(["api/SplunkVisualizationBase","api/SplunkVisualizationUtils"], function(
 	                        // Not yet at the end of the sequence; move down the tree.
 	                        var foundChild = false;
 	                        for (k = 0; k < children.length; k++) {
-	                            if (children[k].name == nodeName) {
+	                            if (children[k].name == nodeName && typeof children[k].children !== "undefined" ) { 
 	                                childNode = children[k];
 	                                foundChild = true;
 	                                break;


### PR DESCRIPTION
Hello  ChrisYounger, 

I found a fatal issue of display sunburst viz graph when children is undefind.

Reproduce log:
[1646206999_102.csv](https://github.com/ChrisYounger/sunburst_viz/files/8167893/1646206999_102.csv)
[1646202514_47.csv](https://github.com/ChrisYounger/sunburst_viz/files/8167894/1646202514_47.csv)

Reproduce SPL on my Splunk 8.2.2 and Sunburst Viz 1.4.5 latest.
`index=_internal 
| eval component = coalesce(component,"") | eval log_level = coalesce(log_level,"") | eval name = coalesce(name,"") 
| stats count by sourcetype component log_level name`

Cause: 
This kind of pattern happens this issue , that comes from "" (null) .
sourcetype,component,"log_level",name,count
"secure_gateway_app_internal_log","","","",1
"secure_gateway_app_internal_log","",INFO,"",1

My debug:
![image](https://user-images.githubusercontent.com/40039738/156323898-4cbe55b8-e202-41c2-9b8e-230a719f0fc4.png)

After this code change, the issue are fixed like this without any errors.
![image](https://user-images.githubusercontent.com/40039738/156324094-bf1d627a-a76f-4e4f-9ebd-f01d674e8169.png)

I'm happy if you merge this and update this app on Splunk Base.
Thank you in advance.
