### PR TITLE
Custom tooltip and colour definition support

### DIFF
--- a/default/data/ui/views/documentation.xml
+++ b/default/data/ui/views/documentation.xml
@@ -58,6 +58,13 @@
 <p>Examples of color themes: <a href="/static/app/sunburst_viz/themes.png"><br /><img alt="" src="/static/app/sunburst_viz/themes.png" style="max-width: 500px;" /></a></p>
 
 <br/>
+<p>You can also specify color definitions using the extended settings</p>
+<h2>Extended color and tooltip options</h2>
+<p>You can add custom tooltip and define the segment color by appending the tooltip and color definition after the value of a field, separating the base value with the additional configuration with a delimiter.</p>
+<pre class="highlight">
+<code>|tstats count where index=* BY index sourcetype source
+| eval sourcetye=printf("%s||%s||%s", sourcetye, "<b style="color:blue">A sourcetype defines the structure and format of data in Splunk"</b>", "#990000")</code></pre>
+<p>will add a bold blue sentence to the standard tooltip and the segment colour will be #990000. Note that this way of defining colors will override any <code>color</code> field in the result</p>
 <br/>
 <br/>
 


### PR DESCRIPTION
I added a config param 'delimiter' with a default as double pipe. I coded so that if the delimiter does not exist then no splitting is done, otherwise it will be split based on the value of that setting.

I'll leave that up to you as to how best you want to expose that. 

I made the tooltip html() rather than text() inside the div, so it can support styling.

Hope this is enough - I left in the existing color field definitions, but the data version will be handled before the color field and in either case, if none are specified, it goes back to it's original way of doing things.
